### PR TITLE
fixed path-resolve

### DIFF
--- a/lib/rules/no-external.js
+++ b/lib/rules/no-external.js
@@ -25,7 +25,7 @@ module.exports = {
       ImportDeclaration(node) {
         const importedPath = node.source.value;
         if (importedPath.indexOf('../') >= 0 || importedPath.indexOf('/') === 0) {
-          const resolvedPath = path.resolve(importedPath);
+          const resolvedPath = path.resolve(context.getFilename(), importedPath);
           if (resolvedPath.indexOf(rootPath) !== 0) {
             context.report({
               node: node.source,


### PR DESCRIPTION
example:
```
// file: src/utils/file.ts
import {App} from '../App';
```

RCA:
`path.resolve(importedPath)` resolved the **importedPath** with the current-working-directory. 
the current-working-directory is the absolute path to the project-root. but **importedPath** in the example above is `../App.ts`. resolved with current-working-directory would be `/path/to/project, ../App.ts` -> `/path/to/App.ts`

with my fix it resolves the **importedPath** with the filepath of the file containing this import-statement. in the example above it would be `/path/to/project/src/utils/file.ts, ../App.ts` `/path/to/project/src/App.ts`